### PR TITLE
Add node Connect error

### DIFF
--- a/db/node.go
+++ b/db/node.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"reflect"
 	"sync"
 )
@@ -36,11 +37,14 @@ func (n *Node) Add(t NodeType, v interface{}) {
 	n.Connect(NewNode(t, v))
 }
 
-func (n *Node) Connect(v *Node) {
+func (n *Node) Connect(v *Node) error {
 	if !n.IsConnected(v) {
 		n.Lock()
 		defer n.Unlock()
 		n.Relations = append(n.Relations, v)
+		return nil
+	} else {
+		return errors.New("node connect: node already connected")
 	}
 }
 

--- a/db/node_test.go
+++ b/db/node_test.go
@@ -13,6 +13,12 @@ func TestNode(t *testing.T) {
 	n1.Connect(n2)
 	n1.Connect(n3)
 
+	// will fail if already connected
+	err := n1.Connect(n3)
+	if err == nil {
+		t.Error("node connect should fail if already connected")
+	}
+
 	// testing table
 	var units = []struct {
 		got interface{} // what we go


### PR DESCRIPTION
This PR adds a simple error if `Connect` function fails for a node. 

Useful for checking if a connection actually succeeded, but is totally optional, and doesn't seem to conflict with the internal API (as it is now).

These errors could probably be formalized at some point later on. 👍