### PR TITLE
Add basic ip to geolocation agent

### DIFF
--- a/agents/ip_to_geolocation_http.go
+++ b/agents/ip_to_geolocation_http.go
@@ -1,0 +1,83 @@
+package agents
+
+import (
+	"encoding/json"
+	"github.com/chimaera/prototype/core"
+	"io/ioutil"
+)
+
+// NOTE: module implemented with help of:
+// https://www.devdungeon.com/content/ip-geolocation-go
+type GeoIP struct {
+	Ip          string  `json:"ip"`
+	CountryCode string  `json:"country_code"`
+	CountryName string  `json:"country_name""`
+	RegionCode  string  `json:"region_code"`
+	RegionName  string  `json:"region_name"`
+	City        string  `json:"city"`
+	Zipcode     string  `json:"zipcode"`
+	Lat         float32 `json:"latitude"`
+	Lon         float32 `json:"longitude"`
+	MetroCode   int     `json:"metro_code"`
+	AreaCode    int     `json:"area_code"`
+}
+
+// TODO: these can obviously be configurable later, and it would
+// be nice to support multiple backends and spread the queries
+// across them.
+const IP2GeoHost = "https://freegeoip.net/json/"
+
+type IP2Geo struct {
+	state        *core.State
+	orchestrator *core.Orchestrator
+}
+
+func NewIP2Geo() *IP2Geo {
+	return &IP2Geo{
+		state: core.NewState(),
+	}
+}
+
+func (c *IP2Geo) ID() string {
+	return "ip:geo:checker"
+}
+
+func (c *IP2Geo) Register(o *core.Orchestrator) error {
+	o.Subscribe(core.NewIP, c.onEndpoint)
+
+	c.orchestrator = o
+
+	return nil
+}
+
+func (c *IP2Geo) onEndpoint(ip string) {
+	if c.state.DidProcess(ip, c.ID()) {
+		return
+	}
+
+	c.state.Add(ip, c.ID())
+
+	c.orchestrator.RunTask(func() {
+		// NOTE: this is sort of hacky, using the same netClient
+		// from the whois http checking agent.
+		resp, err := netClient.Get(IP2GeoHost + ip)
+		if err != nil {
+			panic(err)
+		}
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			panic(err)
+		}
+
+		geo := GeoIP{}
+
+		err = json.Unmarshal(body, &geo)
+		if err != nil {
+			panic(err)
+		}
+
+		c.orchestrator.Publish(core.NewIPGeo, geo)
+	})
+}

--- a/agents/ip_to_geolocation_http.go
+++ b/agents/ip_to_geolocation_http.go
@@ -78,6 +78,6 @@ func (c *IP2Geo) onEndpoint(ip string) {
 			panic(err)
 		}
 
-		c.orchestrator.Publish(core.NewIPGeo, geo)
+		c.orchestrator.Publish(core.NewContent, geo)
 	})
 }

--- a/core/events.go
+++ b/core/events.go
@@ -5,6 +5,7 @@ const (
 	NewDomain     = "new:domain"
 	NewSubdomain  = "new:subdomain"
 	NewIP         = "new:ip"
+	NewIPGeo      = "new:ip:geo"
 	NewWhois      = "new:whois"
 	NewNameServer = "new:nameserver"
 	NewPortTCP    = "new:port:tcp"

--- a/core/events.go
+++ b/core/events.go
@@ -5,7 +5,6 @@ const (
 	NewDomain     = "new:domain"
 	NewSubdomain  = "new:subdomain"
 	NewIP         = "new:ip"
-	NewIPGeo      = "new:ip:geo"
 	NewWhois      = "new:whois"
 	NewNameServer = "new:nameserver"
 	NewPortTCP    = "new:port:tcp"


### PR DESCRIPTION
This PR aims to add basic support for this ( ip-to-geo ) feature.

This agent subscribes to `NewIP` events, searches a ip-to-geolocation service, and emits a `NewIPGeo` event.

**Note:** this agent was implemented with the help of [this lovely example](https://www.devdungeon.com/content/ip-geolocation-go).