### PR TITLE
Initial version of central HTTP proxy with caching capability

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,6 +15,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/elazarl/goproxy"
+  packages = ["."]
+  revision = "91d82cc1070b9ec55e722ab471af64c82b2bcb9c"
+
+[[projects]]
+  branch = "master"
   name = "github.com/moul/http2curl"
   packages = ["."]
   revision = "9ac6cf4d929b2fa8fd2d2e6dec5bb0feb4f4911d"
@@ -64,6 +70,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f47bb0b39fd9310701a224b1608a671d68c9e93d5e588c9a474b232d348e2892"
+  inputs-digest = "7c499e2ec68790fef8069dcb907b9486a4d0c512f771bd6d3d8a7488f12f2b3a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,3 +28,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/elazarl/goproxy"

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -1,0 +1,107 @@
+package core
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/elazarl/goproxy"
+)
+
+var (
+	responseCache *HTTPResponseCache
+	UserAgents    = []string{
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1 Safari/605.1.15",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:60.0) Gecko/20100101 Firefox/60.0",
+		"Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36",
+		"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
+		"Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:60.0) Gecko/20100101 Firefox/60.0",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 Firefox/60.0",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.79 Safari/537.36",
+		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/64.0.3282.119 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.62 Safari/537.36",
+		"Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
+		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Edge/16.16299",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.170 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1 Safari/605.1.15",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.1 Safari/605.1.15",
+		"Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36",
+		"Mozilla/5.0 (X11; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0",
+		"Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko",
+		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.62 Safari/537.36",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/604.5.6 (KHTML, like Gecko) Version/11.0.3 Safari/604.5.6",
+		"Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1",
+		"Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.79 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 6.3; Win64; x64; rv:60.0) Gecko/20100101 Firefox/60.0",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.170 Safari/537.36",
+		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36",
+	}
+)
+
+func checkResponseCache(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+	response, err := GetHTTPResponseCacheInstance().GetResponseCache(r)
+	if err != nil {
+		log.Printf("Error getting response cache: %s\n", err)
+		return r, nil
+	}
+	return r, response
+}
+
+func spoofRequestHeaders(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+	r.Header.Set("User-Agent", randomUserAgent())
+	r.Header.Set("X-Forwarded-For", randomIPV4Address())
+	r.Header.Set("Via", fmt.Sprintf("1.1 %s", randomIPV4Address()))
+	r.Header.Set("Forwarded", fmt.Sprintf("for=%s;proto=http;by=%s", randomIPV4Address(), randomIPV4Address()))
+	return r, nil
+}
+
+func writeResponseCache(r *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+	GetHTTPResponseCacheInstance().WriteResponseCache(r)
+	return r
+}
+
+func NewHTTPProxy() *goproxy.ProxyHttpServer {
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.Verbose = true
+	proxy.OnRequest().DoFunc(checkResponseCache)
+	proxy.OnRequest().DoFunc(spoofRequestHeaders)
+	proxy.OnResponse().DoFunc(writeResponseCache)
+	return proxy
+}
+
+func randomUserAgent() string {
+	return UserAgents[rand.Intn(len(UserAgents))]
+}
+
+func randomIPV4Address() string {
+	rand.Seed(time.Now().UnixNano())
+	blocks := []string{}
+	for i := 0; i < 4; i++ {
+		number := rand.Intn(255)
+		blocks = append(blocks, strconv.Itoa(number))
+	}
+
+	return strings.Join(blocks, ".")
+}

--- a/core/http_response_cache.go
+++ b/core/http_response_cache.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+)
+
+type HTTPResponseCache struct {
+	sync.RWMutex
+	directory string
+}
+
+var (
+	HTTPResponseCacheInstance *HTTPResponseCache
+	once                      sync.Once
+)
+
+func (c *HTTPResponseCache) InitCacheStore() error {
+	dir, err := ioutil.TempDir("", "chimaera-http-response-cache")
+	if err != nil {
+		return err
+	}
+	log.Printf("Saving response caches to: %s\n", dir)
+	c.directory = dir
+	return nil
+}
+
+func (c *HTTPResponseCache) DestroyCacheStore() {
+	os.Remove(c.directory)
+}
+
+func (c *HTTPResponseCache) WriteResponseCache(r *http.Response) error {
+	if !c.cachableRequest(r.Request) {
+		return nil
+	}
+	requestID := c.makeRequestID(r.Request)
+	fileName := fmt.Sprintf("%s/%s", c.directory, requestID)
+	c.Lock()
+	defer c.Unlock()
+	f, err := os.Create(fileName)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	r.Write(f)
+	log.Printf("Wrote cache for %s to %s\n", requestID, fileName)
+	return nil
+}
+
+func (c *HTTPResponseCache) GetResponseCache(r *http.Request) (*http.Response, error) {
+	if !c.cachableRequest(r) {
+		return nil, nil
+	}
+	c.Lock()
+	defer c.Unlock()
+	if !c.hasResponseCache(r) {
+		return nil, nil
+	}
+
+	requestID := c.makeRequestID(r)
+	fileName := fmt.Sprintf("%s/%s", c.directory, requestID)
+	_, err := os.Stat(fileName)
+	if err != nil && os.IsNotExist(err) {
+		return nil, err
+	}
+	cacheEntry, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer cacheEntry.Close()
+	response, err := http.ReadResponse(bufio.NewReader(cacheEntry), r)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (c *HTTPResponseCache) makeRequestID(r *http.Request) string {
+	h := sha1.New()
+	io.WriteString(h, r.Method)
+	io.WriteString(h, r.URL.String())
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func (c *HTTPResponseCache) hasResponseCache(r *http.Request) bool {
+	requestID := c.makeRequestID(r)
+	fileName := fmt.Sprintf("%s/%s", c.directory, requestID)
+	_, err := os.Stat(fileName)
+	if err == nil {
+		return true
+	}
+	return false
+}
+
+func (c *HTTPResponseCache) cachableRequest(r *http.Request) bool {
+	if r.Method == "GET" || r.Method == "HEAD" {
+		return true
+	}
+	return false
+}
+
+// http://marcio.io/2015/07/singleton-pattern-in-go/
+func GetHTTPResponseCacheInstance() *HTTPResponseCache {
+	once.Do(func() {
+		HTTPResponseCacheInstance = &HTTPResponseCache{}
+		HTTPResponseCacheInstance.InitCacheStore()
+	})
+	return HTTPResponseCacheInstance
+}

--- a/core/web.go
+++ b/core/web.go
@@ -3,85 +3,13 @@ package core
 import (
 	"crypto/tls"
 	"github.com/parnurzeal/gorequest"
-	rd "math/rand"
 	"time"
 )
 
 func Get(url string, timeout int) (resp gorequest.Response, body string, errs []error) {
 	// Make a GET request to the target path
-	resp, body, errs = gorequest.New().TLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
-		Timeout(time.Duration(timeout)*time.Second).Get(url).
-		// Can be changed later
-		Set("User-Agent", RandomUserAgent()).
-		End()
+	resp, body, errs = gorequest.New().Proxy("http://localhost:8181").TLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
+		Timeout(time.Duration(timeout) * time.Second).Get(url).End()
 
 	return resp, body, errs
-}
-
-// Adapted from DirSearch by evilsocket. Thanks to him
-// https://github.com/evilsocket/dirsearch :)
-func RandomUserAgent() string {
-	UserAgents := []string{
-		"Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36",
-		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36",
-		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36",
-		"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36",
-		"Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2226.0 Safari/537.36",
-		"Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1",
-		"Mozilla/5.0 (Windows NT 6.3; rv:36.0) Gecko/20100101 Firefox/36.0",
-		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0",
-		"Mozilla/5.0 (X11; Linux i586; rv:31.0) Gecko/20100101 Firefox/31.0",
-		"Mozilla/5.0 (Windows NT 6.1; WOW64; rv:31.0) Gecko/20130401 Firefox/31.0",
-		"Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0",
-		"Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko",
-		"Mozilla/5.0 (compatible, MSIE 11, Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko",
-		"Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0",
-		"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 7.0; InfoPath.3; .NET CLR 3.1.40767; Trident/6.0; en-IN)",
-		"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)",
-		"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)",
-		"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/5.0)",
-		"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/4.0; InfoPath.2; SV1; .NET CLR 2.0.50727; WOW64)",
-		"Mozilla/5.0 (compatible; MSIE 10.0; Macintosh; Intel Mac OS X 10_7_3; Trident/6.0)",
-		"Mozilla/4.0 (Compatible; MSIE 8.0; Windows NT 5.2; Trident/6.0)",
-		"Mozilla/4.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/5.0)",
-		"Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))",
-		"Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0; en-US)",
-		"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)",
-		"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; Media Center PC 6.0; InfoPath.3; MS-RTC LM 8; Zune 4.7)",
-		"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; Media Center PC 6.0; InfoPath.3; MS-RTC LM 8; Zune 4.7",
-		"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; Zune 4.0; InfoPath.3; MS-RTC LM 8; .NET4.0C; .NET4.0E)",
-		"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; chromeframe/12.0.742.112)",
-		"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 2.0.50727; Media Center PC 6.0)",
-		"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 2.0.50727; Media Center PC 6.0)",
-		"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0; .NET CLR 2.0.50727; SLCC2; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; Zune 4.0; Tablet PC 2.0; InfoPath.3; .NET4.0C; .NET4.0E)",
-		"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0",
-		"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; yie8)",
-		"Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; GTB7.4; InfoPath.2; SV1; .NET CLR 3.3.69573; WOW64; en-US)",
-		"Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 1.0.3705; .NET CLR 1.1.4322)",
-		"Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; InfoPath.1; SV1; .NET CLR 3.8.36217; WOW64; en-US)",
-		"Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; .NET CLR 2.7.58687; SLCC2; Media Center PC 5.0; Zune 3.4; Tablet PC 3.6; InfoPath.3)",
-		"Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.2; Trident/4.0; Media Center PC 4.0; SLCC1; .NET CLR 3.0.04320)",
-		"Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 1.1.4322)",
-		"Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727)",
-		"Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
-		"Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; SLCC1; .NET CLR 1.1.4322)",
-		"Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.0; Trident/4.0; InfoPath.1; SV1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 3.0.04506.30)",
-		"Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 5.0; Trident/4.0; FBSMTWB; .NET CLR 2.0.34861; .NET CLR 3.0.3746.3218; .NET CLR 3.5.33652; msn OptimizedIE8;ENUS)",
-		"Mozilla/4.0(compatible; MSIE 7.0b; Windows NT 6.0)",
-		"Mozilla/4.0 (compatible; MSIE 7.0b; Windows NT 6.0)",
-		"Mozilla/4.0 (compatible; MSIE 7.0b; Windows NT 5.2; .NET CLR 1.1.4322; .NET CLR 2.0.50727; InfoPath.2; .NET CLR 3.0.04506.30)",
-		"Mozilla/4.0 (compatible; MSIE 7.0b; Windows NT 5.1; Media Center PC 3.0; .NET CLR 1.0.3705; .NET CLR 1.1.4322; .NET CLR 2.0.50727; InfoPath.1)",
-		"Mozilla/4.0 (compatible; MSIE 7.0b; Windows NT 5.1; FDM; .NET CLR 1.1.4322)",
-		"Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 6.0; en-US)",
-		"Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 6.0; el-GR)",
-		"Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 5.2)",
-		"Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
-		"Mozilla/4.0 (compatible; MSIE 6.1; Windows XP)",
-		"Mozilla/4.0 (compatible; MSIE 6.01; Windows NT 6.0)",
-		"Mozilla/4.0 (compatible; MSIE 6.0b; Windows NT 5.1; DigExt)",
-		"Mozilla/4.0 (compatible; MSIE 6.0b; Windows NT 5.1)",
-	}
-
-	NumberOfUserAgents := len(UserAgents)
-	return UserAgents[rd.Intn(NumberOfUserAgents)]
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	//"log"
+	"net/http"
 
 	"github.com/chimaera/prototype/agents"
 	"github.com/chimaera/prototype/core"
@@ -15,11 +15,14 @@ var (
 func main() {
 	olympus = core.NewOrchestrator(32)
 
+	go http.ListenAndServe(":8181", core.NewHTTPProxy())
+	defer core.GetHTTPResponseCacheInstance().DestroyCacheStore()
+
 	olympus.Register(agents.NewDNSEnum())
 	olympus.Register(agents.NewIPChecker())
 	olympus.Register(agents.NewWhoisChecker())
 	olympus.Register(agents.NewTCPPortscanner())
-	olympus.Register(agents.NewUDPPortscanner())
+	// olympus.Register(agents.NewUDPPortscanner())
 	olympus.Register(agents.NewConfigChecker())
 	olympus.Register(agents.NewTakeoverChecker())
 	agents.RegisterPassiveDNSAgents(olympus)


### PR DESCRIPTION
A central HTTP proxy component for agent HTTP requests, which will give a couple of benefits:

- **Automatic request spoofing**: All requests going through the proxy will automatically get a random user-agent and other headers to spoof the origin or confuse naive rate-limiting systems
- **Caching of responses**: All `GET` and `HEAD` responses will be saved in a temporary directory and loaded when the same request is seen. This is nice in case multiple agents request the same endpoint (e.g. `/` or `/robots.txt`) to do different checks or tasks, it's only the first agent that will perform the actual request, all other agents will just get the cached response.
- **Invalid SSL/TLS setup support for headless chrome**: Apparently headless Chrome can't be configured to tolerate broken SSL/TLS setup such as invalid certificates, but by instructing Chrome to use this proxy, we can cheat it.

**NOTE:** There currently seems to be a strange issue with `CONNECT` requests to https sites ATM. :/